### PR TITLE
Update loyalty threshold from 2 to 5

### DIFF
--- a/models/marts/core/dim_customers.sql
+++ b/models/marts/core/dim_customers.sql
@@ -35,7 +35,7 @@ final as (
         coalesce(customer_orders.number_of_orders, 0) as number_of_orders,
         customer_orders.lifetime_value,
         case
-            when coalesce(customer_orders.number_of_orders, 0) > 2 then 'Loyal'
+            when coalesce(customer_orders.number_of_orders, 0) > 5 then 'Loyal'
             else 'Regular'
         end as loyalty_status
     


### PR DESCRIPTION
Change the threshold for classifying customers as 'Loyal' from > 2 to > 5 orders in `dim_customers.sql`:
```
case
    when coalesce(customer_orders.number_of_orders, 0) > 5 then 'Loyal'
    else 'Regular'
end as loyalty_status

```

